### PR TITLE
Add support for 'CV' barcode type

### DIFF
--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -178,7 +178,7 @@ class Postnl
         $serie = null
     ) {
         // Validate $type parameter.
-        if (!in_array($type, ['2S', '3S', 'CC', 'CP', 'CD', 'CF'])) {
+        if (!in_array($type, ['2S', '3S', 'CC', 'CP', 'CD', 'CF', 'CV'])) {
             throw new Exceptions\InvalidBarcodeTypeException($type);
         }
 


### PR DESCRIPTION
As discussed in the issue, there is a barcode type that may or may not be documented, it seems an up to date version of the documentation is hard to come by.

Dropping the sanity check is a viable alternative, but I do have to admit PostNL's own error messages in the case of an actual wrong barcode type aren't very helpful so it does serve a purpose.

As this is my first time submitting a pull request via GitHub, please let me know if I missed anything anywhere.
