### PR TITLE
Fixed typo in variable name

### DIFF
--- a/src/ComplexTypes/ArrayOfConfirmingResponseShipment.php
+++ b/src/ComplexTypes/ArrayOfConfirmingResponseShipment.php
@@ -18,7 +18,7 @@ class ArrayOfConfirmingResponseShipment extends BaseArrayOfType
      */
     public function __construct(array $ConfirmingResponseShipment)
     {
-        $this->setConfirmingResponseShipment($ConformingResponseShipment);
+        $this->setConfirmingResponseShipment($ConfirmingResponseShipment);
     }
 
     /**


### PR DESCRIPTION
And I'm right back with another pull request :)

This one is pretty straightforward, I didn't run into any actual issues myself, but my IDE notified me of this typo.
