### PR TITLE
Fix bug in CifException handling

### DIFF
--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -374,7 +374,10 @@ class Postnl
 
                 // Assemble exception data from the response.
                 $exceptionData = [];
-                foreach ($exception->detail->CifException->Errors as $error) {
+                $errors = $exception->detail->CifException->Errors->ExceptionData;
+                // Make sure `$errors` is an array.
+                $errors = is_array($errors) ? $errors : [$errors];
+                foreach ($errors as $error) {
                     $exceptionData[] = ComplexTypes\ExceptionData::create()
                         ->setDescription($error->Description)
                         ->setErrorMsg($error->ErrorMsg)


### PR DESCRIPTION
Errors are wrapped in ExceptionData classes.
Without this I got the following error when I submitted an incorrect API call:

```
Trying to get property of non-object in .../dividebv/postnl/src/Postnl.php on line 379
```
