### PR TITLE
Allow Printertype of label to be specified on generateLabel()

### DIFF
--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -274,10 +274,10 @@ class Postnl
      *
      * @see LabellingClient::generateLabel()
      */
-    public function generateLabel(ComplexTypes\Shipment $shipment, $confirm = true)
+    public function generateLabel(ComplexTypes\Shipment $shipment, $confirm = true, $Printertype = 'GraphicFile|PDF')
     {
         // Prepare arguments.
-        $message = new ComplexTypes\LabellingMessage;
+        $message = new ComplexTypes\LabellingMessage($Printertype);
         $customer = new ComplexTypes\Customer($this->customerNumber, $this->customerCode, $this->collectionLocation);
         $request = new ComplexTypes\GenerateLabelRequest($message, $customer, $shipment);
 

--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -270,6 +270,8 @@ class Postnl
      * @param ComplexTypes\Shipment $shipment
      * @param bool $confirm
      *     Defaults to true.
+     * @param string $printerType
+     *     The file type used to generate the label. Defaults to PDF.
      * @return ComplexTypes\ResponseShipment
      *
      * @see LabellingClient::generateLabel()

--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -274,10 +274,10 @@ class Postnl
      *
      * @see LabellingClient::generateLabel()
      */
-    public function generateLabel(ComplexTypes\Shipment $shipment, $confirm = true, $Printertype = 'GraphicFile|PDF')
+    public function generateLabel(ComplexTypes\Shipment $shipment, $confirm = true, $printerType = 'GraphicFile|PDF')
     {
         // Prepare arguments.
-        $message = new ComplexTypes\LabellingMessage($Printertype);
+        $message = new ComplexTypes\LabellingMessage($printerType);
         $customer = new ComplexTypes\Customer($this->customerNumber, $this->customerCode, $this->collectionLocation);
         $request = new ComplexTypes\GenerateLabelRequest($message, $customer, $shipment);
 


### PR DESCRIPTION
Little adjustment so the type that fits best with your local printing situation can be specified.
