### PR TITLE
3S barcodes for EPS parcels are required to be exactly 13 characters

### DIFF
--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -173,6 +173,7 @@ class Postnl
      */
     public function generateBarcode(
         $type,
+        $eps = false,
         $customerCode = null,
         $customerNumber = null,
         $serie = null
@@ -199,6 +200,11 @@ class Postnl
                     // 3S barcodes are the only ones that may be 15 characters
                     // long.
                     $serie = '000000000-999999999';
+                    if ($eps) {
+                      // 3S barcodes for EPS parcels need to be 13 characters
+                      // long.
+                      $serie = '0000000-9999999';
+                    }
                     break;
                 default:
                     // Globalpack is 4 digits, because the barcode is suffixed
@@ -238,15 +244,18 @@ class Postnl
         $customerNumber = null,
         $serie = null
     ) {
+        $eps = false;
         // If this country code has an explicit barcode type mapping, use it.
         if (in_array($countryCode, array_keys($this->countryCodeMapping))) {
             $type = $this->countryCodeMapping[$countryCode];
+            if ($countryCode !== 'NL') {
+              $eps = true;
+            }
         } else {
             // Otherwise use GlobalPack.
             $type = $this->globalPackBarcodeType;
         }
-
-        return $this->generateBarcode($type, $customerCode, $customerNumber, $serie);
+        return $this->generateBarcode($type, $eps, $customerCode, $customerNumber, $serie);
     }
 
     /**

--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -203,9 +203,9 @@ class Postnl
                     // long.
                     $serie = '000000000-999999999';
                     if ($eps) {
-                      // 3S barcodes for EPS parcels need to be 13 characters
-                      // long.
-                      $serie = '0000000-9999999';
+                        // 3S barcodes for EPS parcels need to be 13 characters
+                        // long.
+                        $serie = '0000000-9999999';
                     }
                     break;
                 default:
@@ -247,12 +247,11 @@ class Postnl
         $serie = null
     ) {
         $eps = false;
+
         // If this country code has an explicit barcode type mapping, use it.
         if (in_array($countryCode, array_keys($this->countryCodeMapping))) {
             $type = $this->countryCodeMapping[$countryCode];
-            if ($countryCode !== 'NL') {
-              $eps = true;
-            }
+            $eps = $countryCode != 'NL';
         } else {
             // Otherwise use GlobalPack.
             $type = $this->globalPackBarcodeType;

--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -167,16 +167,18 @@ class Postnl
      *     Defaults to the customer number used to instantiate this object.
      * @param string $serie
      *     Defaults to the widest possible range.
+     * @param bool $eps
+     *     Defaults to false (NL shipment).
      * @return ComplexTypes\GenerateBarcodeResponse
      *
      * @see BarcodeClient::generateBarcode()
      */
     public function generateBarcode(
         $type,
-        $eps = false,
         $customerCode = null,
         $customerNumber = null,
-        $serie = null
+        $serie = null,
+        $eps = false
     ) {
         // Validate $type parameter.
         if (!in_array($type, ['2S', '3S', 'CC', 'CP', 'CD', 'CF', 'CV'])) {
@@ -255,7 +257,7 @@ class Postnl
             // Otherwise use GlobalPack.
             $type = $this->globalPackBarcodeType;
         }
-        return $this->generateBarcode($type, $eps, $customerCode, $customerNumber, $serie);
+        return $this->generateBarcode($type, $customerCode, $customerNumber, $serie, $eps);
     }
 
     /**


### PR DESCRIPTION
Fix that requests correct length barcodes for EPS shipments (see CIF barcode specification 1_1). Currently it is not possible to generate a label for other countries than NL and BE.
