### PR TITLE
Added return type to BaseType::create

### DIFF
--- a/src/ComplexTypes/BaseType.php
+++ b/src/ComplexTypes/BaseType.php
@@ -7,6 +7,8 @@ abstract class BaseType
 
     /**
      * Create a class instance statically without calling the constructor.
+     *
+     * @return $this
      */
     public static function create()
     {


### PR DESCRIPTION
Just a minor quality of life change. I noticed that auto completion in PhpStorm was not working when statically creating objects through `BaseType::create`, which was also causing some inspections to go off in some cases.

Code to get no inspection warnings and autocomplete: 

Before this change:

``` php
/** @var Dimension $dimension */
$dimension = Dimension::create();
$dimension->setWeight('2000');

/** @var Shipment $shipment */
$shipment = Shipment::create();
$shipment->setDimension($dimension);
```

After this change:

``` php
$shipment = Shipment::create()->setDimension(Dimension::create()->setWeight('2000'));
```
