### PR TITLE
Update ConfirmingClient to use API version 1_9

### DIFF
--- a/src/ConfirmingClient.php
+++ b/src/ConfirmingClient.php
@@ -9,12 +9,12 @@ class ConfirmingClient extends BaseClient
     /**
      * The URL of the production WSDL.
      */
-    const PRODUCTION_WSDL = 'https://service.postnl.com/CIF/ConfirmingWebService/1_7/?wsdl';
+    const PRODUCTION_WSDL = 'https://service.postnl.com/CIF/ConfirmingWebService/1_9/?wsdl';
 
     /**
      * The URL of the sandbox WSDL.
      */
-    const SANDBOX_WSDL = 'https://testservice.postnl.com/CIF_SB/ConfirmingWebService/1_7/?wsdl';
+    const SANDBOX_WSDL = 'https://testservice.postnl.com/CIF_SB/ConfirmingWebService/1_9/?wsdl';
 
     /**
      * @var array $classes


### PR DESCRIPTION
No schema changes were made to the API between version 1_7 and 1_9 ([documentation](https://developer.postnl.nl/apis/confirming-webservice/documentation)), so no actual changes to our code are needed.
