### PR TITLE
Feature/labelling client 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ and which aren't. The list of existing services is taken from
 | Geo Adrescheck Nationaal  |      ✗      |   N/A   |
 | Adrescheck Internationaal |      ✗      |   N/A   |
 | Barcode Webservice        |      ✓      |   1_1   |
-| Labelling Webservice      |      ✓      |   1_8   |
+| Labelling Webservice      |      ✓      |   2_0   |
 | Confirming Webservice     |      ✓      |   1_9   |
 | Deliverydate Webservice   |      ✓      |   2_1   |
 | Timeframe Webservice      |      ✓      |   2_0   |

--- a/src/ComplexTypes/ArrayOfMergedLabel.php
+++ b/src/ComplexTypes/ArrayOfMergedLabel.php
@@ -1,0 +1,41 @@
+<?php namespace DivideBV\Postnl\ComplexTypes;
+
+class ArrayOfMergedLabel extends BaseArrayOfType
+{
+
+    /**
+     * The name of the array property this class is a wrapper of.
+     */
+    const WRAPPED_PROPERTY = 'MergedLabel';
+
+    /**
+     * @var MergedLabel[] $MergedLabel
+     */
+    protected $MergedLabel = null;
+
+    /**
+     * @param MergedLabel[] $MergedLabel
+     */
+    public function __construct(array $MergedLabel)
+    {
+        $this->setMergedLabel($MergedLabel);
+    }
+
+    /**
+     * @return MergedLabel[]
+     */
+    public function getMergedLabel()
+    {
+        return $this->MergedLabel;
+    }
+
+    /**
+     * @param MergedLabel[] $MergedLabel
+     * @return ArrayOfMergedLabel
+     */
+    public function setMergedLabel(array $MergedLabel)
+    {
+        $this->MergedLabel = $MergedLabel;
+        return $this;
+    }
+}

--- a/src/ComplexTypes/ArrayOfResponseShipment.php
+++ b/src/ComplexTypes/ArrayOfResponseShipment.php
@@ -1,0 +1,41 @@
+<?php namespace DivideBV\Postnl\ComplexTypes;
+
+class ArrayOfResponseShipment extends BaseArrayOfType
+{
+
+    /**
+     * The name of the array property this class is a wrapper of.
+     */
+    const WRAPPED_PROPERTY = 'ResponseShipment';
+
+    /**
+     * @var ResponseShipment[] $ResponseShipment
+     */
+    protected $ResponseShipment = null;
+
+    /**
+     * @param ResponseShipment[] $ResponseShipment
+     */
+    public function __construct(array $ResponseShipment)
+    {
+        $this->setResponseShipment($ResponseShipment);
+    }
+
+    /**
+     * @return ResponseShipment[]
+     */
+    public function getResponseShipment()
+    {
+        return $this->ResponseShipment;
+    }
+
+    /**
+     * @param ResponseShipment[] $ResponseShipment
+     * @return ArrayOfResponseShipment
+     */
+    public function setResponseShipment(array $ResponseShipment)
+    {
+        $this->ResponseShipment = $ResponseShipment;
+        return $this;
+    }
+}

--- a/src/ComplexTypes/GenerateLabelRequest.php
+++ b/src/ComplexTypes/GenerateLabelRequest.php
@@ -14,20 +14,31 @@ class GenerateLabelRequest extends BaseType
     protected $Customer = null;
 
     /**
-     * @var Shipment $Shipment
+     * @var ArrayOfShipment $Shipments
      */
-    protected $Shipment = null;
+    protected $Shipments = null;
+
+    /**
+     * @var base64Binary $LabelSignature
+     */
+    protected $LabelSignature;
 
     /**
      * @param LabellingMessage $Message
      * @param Customer $Customer
-     * @param Shipment $Shipment
+     * @param ArrayOfShipment $Shipments
+     * @param base64Binary $LabelSignature
      */
-    public function __construct(LabellingMessage $Message, Customer $Customer, Shipment $Shipment)
-    {
+    public function __construct(
+        LabellingMessage $Message,
+        Customer $Customer,
+        ArrayOfShipment $Shipments,
+        $LabelSignature = null
+    ) {
         $this->setMessage($Message);
         $this->setCustomer($Customer);
-        $this->setShipment($Shipment);
+        $this->setShipments($Shipments);
+        $this->setLabelSignature($LabelSignature);
     }
 
     /**
@@ -69,18 +80,36 @@ class GenerateLabelRequest extends BaseType
     /**
      * @return Shipment
      */
-    public function getShipment()
+    public function getShipments()
     {
         return $this->Shipment;
     }
 
     /**
-     * @param Shipment $Shipment
+     * @param ArrayOfShipment $Shipments
      * @return GenerateLabelRequest
      */
-    public function setShipment(Shipment $Shipment)
+    public function setShipments(ArrayOfShipment $Shipments)
     {
-        $this->Shipment = $Shipment;
+        $this->Shipments = $Shipments;
+        return $this;
+    }
+
+    /**
+     * @return base64Binary
+     */
+    public function getLabelSignature()
+    {
+        return $this->LabelSignature;
+    }
+
+    /**
+     * @param base64Binary $LabelSignature
+     * @return GenerateLabelRequest
+     */
+    public function setLabelSignature($LabelSignature)
+    {
+        $this->LabelSignature = $LabelSignature;
         return $this;
     }
 }

--- a/src/ComplexTypes/GenerateLabelRequest.php
+++ b/src/ComplexTypes/GenerateLabelRequest.php
@@ -78,11 +78,11 @@ class GenerateLabelRequest extends BaseType
     }
 
     /**
-     * @return Shipment
+     * @return ArrayOfShipment
      */
     public function getShipments()
     {
-        return $this->Shipment;
+        return $this->Shipments;
     }
 
     /**

--- a/src/ComplexTypes/GenerateLabelResponse.php
+++ b/src/ComplexTypes/GenerateLabelResponse.php
@@ -1,0 +1,63 @@
+<?php namespace DivideBV\Postnl\ComplexTypes;
+
+class GenerateLabelResponse extends BaseType
+{
+
+    /**
+     * @var ArrayOfMergedLabel $MergedLabels
+     */
+    protected $MergedLabels = null;
+
+    /**
+     * @var ArrayOfResponseShipment $ResponseShipments
+     */
+    protected $ResponseShipments = null;
+
+    /**
+     * @param ArrayOfMergedLabel $MergedLabels
+     * @param ArrayOfResponseShipment $ResponseShipments
+     */
+    public function __construct(
+        ArrayOfMergedLabel $MergedLabels = null,
+        ArrayOfResponseShipment $ResponseShipments = null
+    ) {
+        $this->setMergedLabels($MergedLabels);
+        $this->setResponseShipments($ResponseShipments);
+    }
+
+    /**
+     * @return ArrayOfMergedLabel
+     */
+    public function getMergedLabels()
+    {
+        return $this->MergedLabels;
+    }
+
+    /**
+     * @param ArrayOfMergedLabel $MergedLabels
+     * @return GenerateLabelResponse
+     */
+    public function setMergedLabels($MergedLabels)
+    {
+        $this->MergedLabels = $MergedLabels;
+        return $this;
+    }
+
+    /**
+     * @return ArrayOfResponseShipment
+     */
+    public function getResponseShipments()
+    {
+        return $this->ResponseShipments;
+    }
+
+    /**
+     * @param ArrayOfResponseShipment $ResponseShipments
+     * @return GenerateLabelResponse
+     */
+    public function setResponseShipments($ResponseShipments)
+    {
+        $this->ResponseShipments = $ResponseShipments;
+        return $this;
+    }
+}

--- a/src/ComplexTypes/MergedLabel.php
+++ b/src/ComplexTypes/MergedLabel.php
@@ -1,0 +1,61 @@
+<?php namespace DivideBV\Postnl\ComplexTypes;
+
+class MergedLabel extends BaseType
+{
+
+    /**
+     * @var string[] $Barcodes
+     */
+    protected $Barcodes = null;
+
+    /**
+     * @var ArrayOfLabel $Labels
+     */
+    protected $Labels = null;
+
+    /**
+     * @var string[] $Barcodes
+     * @var ArrayOfLabel $Labels
+     */
+    public function __construct(array $Barcodes, ArrayOfLabel $Labels)
+    {
+        $this->setBarcodes($Barcodes);
+        $this->setLabels($Labels);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getBarcodes()
+    {
+        return $this->Barcodes;
+    }
+
+    /**
+     * @param string[] $Barcodes
+     * @return MergedLabel
+     */
+    public function setBarcodes($Barcodes)
+    {
+        $this->Barcodes = $Barcodes;
+        return $this;
+    }
+
+    /**
+     * @return ArrayOfLabel
+     */
+    public function getLabels()
+    {
+      return $this->Labels;
+    }
+
+    /**
+     * @param ArrayOfLabel $Labels
+     * @return MergedLabel
+     */
+    public function setLabels($Labels)
+    {
+        $this->Labels = $Labels;
+        return $this;
+    }
+}

--- a/src/LabellingClient.php
+++ b/src/LabellingClient.php
@@ -9,12 +9,12 @@ class LabellingClient extends BaseClient
     /**
      * The URL of the production WSDL.
      */
-    const PRODUCTION_WSDL = 'https://service.postnl.com/CIF/LabellingWebService/1_8/?wsdl';
+    const PRODUCTION_WSDL = 'https://service.postnl.com/CIF/LabellingWebService/2_0/?wsdl';
 
     /**
      * The URL of the sandbox WSDL.
      */
-    const SANDBOX_WSDL = 'https://testservice.postnl.com/CIF_SB/LabellingWebService/1_8/?wsdl';
+    const SANDBOX_WSDL = 'https://testservice.postnl.com/CIF_SB/LabellingWebService/2_0/?wsdl';
 
     /**
      * @var array $classes
@@ -25,6 +25,7 @@ class LabellingClient extends BaseClient
         'Customer',
         'Address',
         'Message',
+        'ArrayOfShipment',
         'Shipment',
         'ArrayOfAddress',
         'ArrayOfAmount',
@@ -39,9 +40,13 @@ class LabellingClient extends BaseClient
         'Group',
         'ArrayOfProductOption',
         'ProductOption',
+        'GenerateLabelResponse',
+        'ArrayOfMergedLabel',
+        'MergedLabel',
         'ResponseShipment',
         'ArrayOfLabel',
         'Label',
+        'ArrayOfResponseShipment',
         'ArrayOfWarning',
         'Warning',
     ];

--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -307,7 +307,7 @@ class Postnl
         // Prepare arguments.
         $message = new ComplexTypes\LabellingMessage($printerType);
         $customer = new ComplexTypes\Customer($this->customerNumber, $this->customerCode, $this->collectionLocation);
-        $request = new ComplexTypes\GenerateLabelRequest($message, $customer, $shipment);
+        $request = new ComplexTypes\GenerateLabelRequest($message, $customer, new ComplexTypes\ArrayOfShipment([$shipment]));
 
         // Query the webservice and return the result.
         return $this->call('LabellingClient', $confirm ? __FUNCTION__ : 'generateLabelWithoutConfirm', $request);

--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -304,13 +304,10 @@ class Postnl
      */
     public function generateLabel(ComplexTypes\Shipment $shipment, $printerType = 'GraphicFile|PDF', $confirm = true)
     {
-        // Prepare arguments.
-        $message = new ComplexTypes\LabellingMessage($printerType);
-        $customer = new ComplexTypes\Customer($this->customerNumber, $this->customerCode, $this->collectionLocation);
-        $request = new ComplexTypes\GenerateLabelRequest($message, $customer, new ComplexTypes\ArrayOfShipment([$shipment]));
+        $result = $this->generateLabels(new ComplexTypes\ArrayOfShipment([$shipment]), $printerType, $confirm);
 
-        // Query the webservice and return the result.
-        return $this->call('LabellingClient', $confirm ? __FUNCTION__ : 'generateLabelWithoutConfirm', $request);
+        // Return only the first shipment (there should be only 1).
+        return reset($result->getResponseShipments());
     }
 
     /**
@@ -324,6 +321,45 @@ class Postnl
     public function generateLabelWithoutConfirm(ComplexTypes\Shipment $shipment, $printerType = 'GraphicFile|PDF')
     {
         return $this->generateLabel($shipment, $printerType, false);
+    }
+
+    /**
+     * @param ComplexTypes\ArrayOfShipment $shipments
+     * @param string $printerType
+     *     The file type used to generate the label. Defaults to PDF.
+     * @param bool $confirm
+     *     Defaults to true.
+     * @return ComplexTypes\GenerateLabelResponse
+     *
+     * @see LabellingClient::generateLabel()
+     */
+    public function generateLabels(
+        ComplexTypes\ArrayOfShipment $shipments,
+        $printerType = 'GraphicFile|PDF',
+        $confirm = true
+    ) {
+        // Prepare arguments.
+        $message = new ComplexTypes\LabellingMessage($printerType);
+        $customer = new ComplexTypes\Customer($this->customerNumber, $this->customerCode, $this->collectionLocation);
+        $request = new ComplexTypes\GenerateLabelRequest($message, $customer, $shipments);
+
+        // Query the webservice and return the result.
+        return $this->call('LabellingClient', $confirm ? 'generateLabel' : 'generateLabelWithoutConfirm', $request);
+    }
+
+    /**
+     * @param ComplexTypes\ArrayOfShipment $shipments
+     * @param string $printerType
+     *     The file type used to generate the label. Defaults to PDF.
+     * @return ComplexTypes\GenerateLabelResponse
+     *
+     * @see LabellingClient::generateLabelWithoutConfirm()
+     */
+    public function generateLabelsWithoutConfirm(
+        ComplexTypes\ArrayOfShipment $shipments,
+        $printerType = 'GraphicFile|PDF'
+    ) {
+        return $this->generateLabels($shipments, $printerType, false);
     }
 
     /**


### PR DESCRIPTION
Updates the LabellingClient to `2_0`, which breaks backward compatibility. I implemented it in a backward compatible way in the library.

PS: the fact that this update doesn't break backward compatibility means that I'll probably release `1.0.0` soon, as it seems feasible to stay compatible.
