### PR TITLE
Fixed issue where non-variable was passed as reference

### DIFF
--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -305,10 +305,8 @@ class Postnl
     public function generateLabel(ComplexTypes\Shipment $shipment, $printerType = 'GraphicFile|PDF', $confirm = true)
     {
         $result = $this->generateLabels(new ComplexTypes\ArrayOfShipment([$shipment]), $printerType, $confirm);
-
-        $responseShipments = $result->getResponseShipments();
         // Return only the first shipment (there should be only 1).
-        return reset($responseShipments);
+        return $result->getResponseShipments()->getShipment()[0];
     }
 
     /**

--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -306,8 +306,9 @@ class Postnl
     {
         $result = $this->generateLabels(new ComplexTypes\ArrayOfShipment([$shipment]), $printerType, $confirm);
 
+        $responseShipments = $result->getResponseShipments();
         // Return only the first shipment (there should be only 1).
-        return reset($result->getResponseShipments());
+        return reset($responseShipments);
     }
 
     /**


### PR DESCRIPTION
This resolves an issue where calling Postnl::generateLabel on version `1.0.0` causes an ErrorException to be thrown at `dividebv/postnl/­src/­Postnl.php:310` with the following message `Only variables should be passed by reference`.

This issue currently breaks implementations upgraded from `0.11.0` to `1.0.0`
