### PR TITLE
Fix issues with SOAP_SINGLE_ELEMENT_ARRAYS

### DIFF
--- a/src/BaseClient.php
+++ b/src/BaseClient.php
@@ -42,7 +42,11 @@ abstract class BaseClient extends SoapClient
             $wsdl = $sandbox ? static::SANDBOX_WSDL : static::PRODUCTION_WSDL;
         }
 
-        parent::__construct($wsdl, ['classmap' => $this->getClassmap(), 'trace' => true]);
+        parent::__construct($wsdl, [
+            'classmap' => $this->getClassmap(),
+            'trace' => true,
+            'features' => SOAP_SINGLE_ELEMENT_ARRAYS
+        ]);
 
         $this->__setSoapHeaders($SecurityHeader);
     }

--- a/src/ComplexTypes/BaseArrayOfType.php
+++ b/src/ComplexTypes/BaseArrayOfType.php
@@ -19,9 +19,6 @@ abstract class BaseArrayOfType extends BaseType implements IteratorAggregate
      */
     public function getIterator()
     {
-        // When created by the SOAP stack, the property may not be an array.
-        $property = $this->{static::WRAPPED_PROPERTY};
-        $iterable = is_array($property) ? $property : [$property];
-        return new ArrayIterator($iterable);
+        return new ArrayIterator($this->{static::WRAPPED_PROPERTY});
     }
 }

--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -562,10 +562,7 @@ class Postnl
 
                 // Assemble exception data from the response.
                 $exceptionData = [];
-                $errors = $exception->detail->CifException->Errors->ExceptionData;
-                // Make sure `$errors` is an array.
-                $errors = is_array($errors) ? $errors : [$errors];
-                foreach ($errors as $error) {
+                foreach ($exception->detail->CifException->Errors->ExceptionData as $error) {
                     $exceptionData[] = ComplexTypes\ExceptionData::create()
                         ->setDescription($error->Description)
                         ->setErrorMsg($error->ErrorMsg)

--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -562,7 +562,10 @@ class Postnl
 
                 // Assemble exception data from the response.
                 $exceptionData = [];
-                foreach ($exception->detail->CifException->Errors->ExceptionData as $error) {
+                $errors = $exception->detail->CifException->Errors->ExceptionData;
+                // Make sure `$errors` is an array.
+                $errors = is_array($errors) ? $errors : [$errors];
+                foreach ($errors as $error) {
                     $exceptionData[] = ComplexTypes\ExceptionData::create()
                         ->setDescription($error->Description)
                         ->setErrorMsg($error->ErrorMsg)

--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -306,7 +306,7 @@ class Postnl
     {
         $result = $this->generateLabels(new ComplexTypes\ArrayOfShipment([$shipment]), $printerType, $confirm);
         // Return only the first shipment (there should be only 1).
-        return $result->getResponseShipments()->getShipment()[0];
+        return $result->getResponseShipments()->getResponseShipment()[0];
     }
 
     /**


### PR DESCRIPTION
This should fix issues where SOAP arrays with a single element are not created as arrays.

Untested, please test and do not merge yet!
