### PR TITLE
getLocationsInArea function added

### DIFF
--- a/src/LocationClient.php
+++ b/src/LocationClient.php
@@ -58,4 +58,13 @@ class LocationClient extends BaseClient
     {
         return $this->__soapCall('GetLocation', [$getLocations]);
     }
+    
+    /**
+     * @param ComplexTypes\GetNearestLocationsRequest $getLocationsInArea
+     * @return ComplexTypes\GetLocationsResult
+     */
+    public function getLocationsInArea(ComplexTypes\GetLocationsInAreaRequest $getLocationsInArea)
+    {
+        return $this->__soapCall('GetLocationsInArea', [$getLocationsInArea]);
+    }
 }

--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -417,6 +417,35 @@ class Postnl
         $request = new ComplexTypes\GetNearestLocationsRequest($message, $location, $countryCode);
         return $this->call('LocationClient', __FUNCTION__, $request);
     }
+    
+    /**
+     * @param ComplexTypes\Coordinate $coordinatesNorthWest
+     * @param ComplexTypes\Coordinate $coordinatesSouthEast
+     * @param string $allowSundaySorting
+     * @param null|string $deliveryDate
+     * @param array $deliveryOptions
+     * @param array $options
+     * @param string $countryCode
+     * @return ComplexTypes\GetNearestLocationsResponse
+     */
+    public function getLocationsInArea(
+        $coordinatesNorthWest,
+        $coordinatesSouthEast,
+        $allowSundaySorting = 'false',
+        $deliveryDate = null,
+        $deliveryOptions = null,
+        $options = ['Daytime'],
+        $countryCode = 'NL'
+    ) {
+        $message = new ComplexTypes\Message;
+        $locationArea = new ComplexTypes\LocationArea($allowSundaySorting, $deliveryDate, $deliveryOptions, $options);
+        $locationArea
+                ->setCoordinatesNorthWest($coordinatesNorthWest)
+                ->setCoordinatesSouthEast($coordinatesSouthEast);
+
+        $request = new ComplexTypes\GetLocationsInAreaRequest($countryCode, $locationArea, $message);
+        return $this->call('LocationClient', __FUNCTION__, $request);
+    }
 
     /**
      * @param string $postalCode

--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -429,8 +429,8 @@ class Postnl
      * @return ComplexTypes\GetNearestLocationsResponse
      */
     public function getLocationsInArea(
-        $coordinatesNorthWest,
-        $coordinatesSouthEast,
+        ComplexTypes\Coordinate $coordinatesNorthWest,
+        ComplexTypes\Coordinate $coordinatesSouthEast,
         $allowSundaySorting = 'false',
         $deliveryDate = null,
         $deliveryOptions = null,

--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -438,10 +438,15 @@ class Postnl
         $countryCode = 'NL'
     ) {
         $message = new ComplexTypes\Message;
-        $locationArea = new ComplexTypes\LocationArea($allowSundaySorting, $deliveryDate, $deliveryOptions, $options);
-        $locationArea
-                ->setCoordinatesNorthWest($coordinatesNorthWest)
-                ->setCoordinatesSouthEast($coordinatesSouthEast);
+        
+        $deliveryDate = $deliveryDate ?: (new \DateTime('next monday'))->format('d-m-Y');
+        $locationArea = ComplexTypes\LocationArea::create()
+            ->setAllowSundaySorting($allowSundaySorting)
+            ->setDeliveryDate($deliveryDate)
+            ->setDeliveryOptions($deliveryOptions)
+            ->setOptions($options)
+            ->setCoordinatesNorthWest($coordinatesNorthWest)
+            ->setCoordinatesSouthEast($coordinatesSouthEast);
 
         $request = new ComplexTypes\GetLocationsInAreaRequest($countryCode, $locationArea, $message);
         return $this->call('LocationClient', __FUNCTION__, $request);


### PR DESCRIPTION
Retrieves PostNL Locations in specific area.
Code Example:

```
$coordinatesNorthWest = \DivideBV\Postnl\ComplexTypes\Coordinate::create()
    ->setLongitude(5.085307)
    ->setLatitude(52.118860);
$coordinatesSouthEast = \DivideBV\Postnl\ComplexTypes\Coordinate::create()
    ->setLongitude(5.135604)
    ->setLatitude(52.079527);
$locations = $postNL->getLocationsInArea(
    $coordinatesNorthWest,
    $coordinatesSouthEast,
    'false',
    null,
    ['PG', 'PGE'],
    ['Daytime'],
    'NL');
```