### PR TITLE
Implement PostNL location EasyReturn Webservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ and which aren't. The list of existing services is taken from
 | Timeframe Webservice      |      ✓      |   2_0   |
 | Location Webservice       |      ✓      |   2_1   |
 | Shippingstatus Webservice |      ✓      |   1_6   |
+| EasyReturn WebService     |      ✓      |   1_5   |
 
 # Example
 

--- a/src/ComplexTypes/GenerateReturnLabelRequest.php
+++ b/src/ComplexTypes/GenerateReturnLabelRequest.php
@@ -1,0 +1,89 @@
+<?php namespace DivideBV\Postnl\ComplexTypes;
+
+class GenerateReturnLabelRequest extends BaseType
+{
+
+    /**
+     * @var Message $Message
+     */
+    protected $Message = null;
+
+    /**
+     * @var Customer $Customer
+     */
+    protected $Customer = null;
+
+    /**
+     * @var Shipment $Shipment
+     */
+    protected $Shipment = null;
+
+    /**
+     * @param Message $Message
+     * @param Customer $Customer
+     * @param Shipment $Shipment
+     */
+    public function __construct(Message $Message, Customer $Customer, Shipment $Shipment)
+    {
+        $this->setMessage($Message);
+        $this->setCustomer($Customer);
+        $this->setShipment($Shipment);
+    }
+
+
+    /**
+     * @return Message
+     */
+    public function getMessage()
+    {
+        return $this->Message;
+    }
+
+    /**
+     * @param Message $Message
+     * @return GenerateLabelRequest
+     */
+    public function setMessage(Message $Message)
+    {
+        $this->Message = $Message;
+        return $this;
+    }
+
+
+
+    /**
+     * @return Customer
+     */
+    public function getCustomer()
+    {
+        return $this->Customer;
+    }
+
+    /**
+     * @param Customer $Customer
+     * @return GenerateReturnLabelRequest
+     */
+    public function setCustomer(Customer $Customer)
+    {
+        $this->Customer = $Customer;
+        return $this;
+    }
+
+    /**
+     * @return Shipment
+     */
+    public function getShipment()
+    {
+        return $this->Shipment;
+    }
+
+    /**
+     * @param Shipment $Shipment
+     * @return GenerateReturnLabelRequest
+     */
+    public function setShipment(Shipment $Shipment)
+    {
+        $this->Shipment = $Shipment;
+        return $this;
+    }
+}

--- a/src/ComplexTypes/GenerateReturnLabelRequest.php
+++ b/src/ComplexTypes/GenerateReturnLabelRequest.php
@@ -30,7 +30,6 @@ class GenerateReturnLabelRequest extends BaseType
         $this->setShipment($Shipment);
     }
 
-
     /**
      * @return Message
      */
@@ -48,8 +47,6 @@ class GenerateReturnLabelRequest extends BaseType
         $this->Message = $Message;
         return $this;
     }
-
-
 
     /**
      * @return Customer

--- a/src/ComplexTypes/GenerateReturnLabelResponse.php
+++ b/src/ComplexTypes/GenerateReturnLabelResponse.php
@@ -1,0 +1,63 @@
+<?php namespace DivideBV\Postnl\ComplexTypes;
+
+class GenerateReturnLabelResponse extends BaseType
+{
+
+    /**
+     * @var ArrayOfLabel $Labels
+     */
+    protected $Labels = null;
+
+    /**
+     * @var ArrayOfWarning $Warnings
+     */
+    protected $Warnings = null;
+
+    /**
+     * @param ArrayOfLabel $Labels
+     * @param ArrayOfWarning $Warnings
+     */
+    public function __construct(
+        ArrayOfLabel $Labels = null,
+        ArrayOfWarning $Warnings = null
+    ) {
+        $this->setLabels($Labels);
+        $this->setWarnings($Warnings);
+    }
+
+    /**
+     * @return ArrayOfLabel
+     */
+    public function getLabels()
+    {
+        return $this->Labels;
+    }
+
+    /**
+     * @param ArrayOfLabel $Labels
+     * @return GenerateReturnLabelResponse
+     */
+    public function setLabels($Labels)
+    {
+        $this->Labels = $Labels;
+        return $this;
+    }
+
+    /**
+     * @return ArrayOfWarning
+     */
+    public function getWarnings()
+    {
+        return $this->Warnings;
+    }
+
+    /**
+     * @param ArrayOfWarning $Warnings
+     * @return GenerateReturnLabelResponse
+     */
+    public function setWarnings($Warnings)
+    {
+        $this->Warnings = $Warnings;
+        return $this;
+    }
+}

--- a/src/ComplexTypes/GenerateReturnLabelResponse.php
+++ b/src/ComplexTypes/GenerateReturnLabelResponse.php
@@ -17,10 +17,8 @@ class GenerateReturnLabelResponse extends BaseType
      * @param ArrayOfLabel $Labels
      * @param ArrayOfWarning $Warnings
      */
-    public function __construct(
-        ArrayOfLabel $Labels = null,
-        ArrayOfWarning $Warnings = null
-    ) {
+    public function __construct(ArrayOfLabel $Labels = null, ArrayOfWarning $Warnings = null ) 
+    {
         $this->setLabels($Labels);
         $this->setWarnings($Warnings);
     }

--- a/src/EasyReturnServiceClient.php
+++ b/src/EasyReturnServiceClient.php
@@ -1,0 +1,64 @@
+<?php namespace DivideBV\Postnl;
+
+/**
+ * Client class for CIF's location service.
+ */
+class EasyReturnServiceClient extends BaseClient
+{
+
+    /**
+     * The URL of the production WSDL.
+     */
+    const PRODUCTION_WSDL = 'https://service.postnl.com/CIF/EasyReturnWebService/1_5/?wsdl';
+
+    /**
+     * The URL of the sandbox WSDL.
+     */
+    const SANDBOX_WSDL = 'https://testservice.postnl.com/CIF_SB/EasyReturnWebService/1_5/?wsdl';
+
+    /**
+     * @var array $classes
+     *     The complex types used by this client.
+     */
+    protected $classes = [
+        'GenerateLabelRequest',
+        'GenerateReturnLabelRequest',
+        'Customer',
+        'Address',
+        'Message',
+        'ArrayOfShipment',
+        'Shipment',
+        'ArrayOfAddress',
+        'ArrayOfAmount',
+        'Amount',
+        'ArrayOfContact',
+        'Contact',
+        'Customs',
+        'ArrayOfContent',
+        'Content',
+        'Dimension',
+        'ArrayOfGroup',
+        'Group',
+        'ArrayOfProductOption',
+        'ProductOption',
+        'GenerateLabelResponse',
+        'GenerateReturnLabelResponse',
+        'ArrayOfMergedLabel',
+        'MergedLabel',
+        'ResponseShipment',
+        'ArrayOfLabel',
+        'Label',
+        'ArrayOfResponseShipment',
+        'ArrayOfWarning',
+        'Warning',
+    ];
+
+    /**
+     * @param ComplexTypes\GenerateReturnLabelRequest $generateReturnLabel
+     * @return ComplexTypes\GenerateReturnLabelResponse
+     */
+    public function generateReturnLabel(ComplexTypes\GenerateReturnLabelRequest $generateReturnLabel)
+    {
+        return $this->__soapCall('GenerateReturnLabel', [$generateReturnLabel]);
+    }
+}

--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -324,6 +324,29 @@ class Postnl
     }
 
     /**
+     * @param ComplexTypes\Shipment $shipment
+     * @param string $contactPerson
+     * @param string $email
+     * @return ComplexTypes\GenerateReturnLabelResponse
+     *
+     * @see LabellingClient::generateLabel()
+     */
+    public function generateReturnLabel(
+        ComplexTypes\Shipment $shipment,
+        $contactPerson,
+        $email
+    ) {
+        // Prepare arguments.
+        $message = new ComplexTypes\Message();
+        $customer = new ComplexTypes\Customer($this->customerNumber, $this->customerCode, $this->collectionLocation,
+            $contactPerson, $email, $this->customerName);
+        $request = new ComplexTypes\GenerateReturnLabelRequest($message, $customer, $shipment);
+
+        // Query the webservice and return the result.
+        return $this->call('EasyReturnServiceClient', __FUNCTION__, $request);
+    }    
+    
+    /**
      * @param ComplexTypes\ArrayOfShipment $shipments
      * @param string $printerType
      *     The file type used to generate the label. Defaults to PDF.

--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -338,8 +338,11 @@ class Postnl
     ) {
         // Prepare arguments.
         $message = new ComplexTypes\Message();
-        $customer = new ComplexTypes\Customer($this->customerNumber, $this->customerCode, $this->collectionLocation,
-            $contactPerson, $email, $this->customerName);
+        $customer = new ComplexTypes\Customer($this->customerNumber, $this->customerCode, $this->collectionLocation);
+        $customer->setContactPerson($contactPerson);
+        $customer->setEmail($email);
+        $customer->setName($this->customerName);
+        
         $request = new ComplexTypes\GenerateReturnLabelRequest($message, $customer, $shipment);
 
         // Query the webservice and return the result.

--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -331,11 +331,8 @@ class Postnl
      *
      * @see LabellingClient::generateLabel()
      */
-    public function generateReturnLabel(
-        ComplexTypes\Shipment $shipment,
-        $contactPerson,
-        $email
-    ) {
+    public function generateReturnLabel(ComplexTypes\Shipment $shipment, $contactPerson, $email) 
+    {
         // Prepare arguments.
         $message = new ComplexTypes\Message();
         $customer = new ComplexTypes\Customer($this->customerNumber, $this->customerCode, $this->collectionLocation);


### PR DESCRIPTION
Added support for PostNL  EasyReturn Webservice. This webservice generates return labels in PDF format for use with return shipments from outside the Netherlands.
I've created:
ComplexTypes/GenerateReturnLabelRequest.php
ComplexTypes/GenerateReturnLabelResponse.php
Modified Postnl.nl, added generateReturnLabel() function.

Easyreturn label is created like this:

```
$barcode = '3SXXXX123456';
$receiverAddress = \DivideBV\Postnl\ComplexTypes\Address::create()
    ->setAddressType('01')
    ->setFirstName('Jan')
    ->setName('Smit')
    ->setCompanyName(Smit & Zonen')
    ->setStreet('Hoofdstraat')
    ->setHouseNr('1')
    ->setHouseNrExt('A')
    ->setZipcode('1234AB')
    ->setCity('Heikant')
    ->setCountrycode('NL');

$senderAddress = \DivideBV\Postnl\ComplexTypes\Address::create()
    ->setAddressType('02')
    ->setFirstName('John')
    ->setName('Doe')
    ->setCompanyName('')
    ->setStreet('Wiertzstraat')
    ->setHouseNr('60')
    ->setHouseNrExt('')
    ->setZipcode('1047')
    ->setCity('Brussel')
    ->setCountrycode('BE');

$contact = \DivideBV\Postnl\ComplexTypes\Contact::create()
    ->setContactType('01')
    ->setEmail('info@example.com');

$shipment = \DivideBV\Postnl\ComplexTypes\Shipment::create()
    ->setAddresses(new \DivideBV\Postnl\ComplexTypes\ArrayOfAddress([
        $receiverAddress,
        $senderAddress,
    ]))
    ->setContacts(new \DivideBV\Postnl\ComplexTypes\ArrayOfContact([
        $contact,
    ]))
    ->setBarcode($barcode)
    ->setDimension(\DivideBV\Postnl\ComplexTypes\Dimension::create()
        ->setWeight(1000) // Weight in g
    );

$shipment->setProductCodeDelivery('04910');
$result = $client->generateReturnLabel($shipment, 'Jan Smit', 'info@example.com');
$label = $result->getLabels()[0];
$file = new \SplFileObject("label.pdf", 'w');
$file->fwrite($label->getContent());
```
