### PR TITLE
Use current version of the labelling webservice

### DIFF
--- a/src/LabellingClient.php
+++ b/src/LabellingClient.php
@@ -9,12 +9,12 @@ class LabellingClient extends BaseClient
     /**
      * The URL of the production WSDL.
      */
-    const PRODUCTION_WSDL = 'https://service.postnl.com/CIF/LabellingWebService/2_0/?wsdl';
+    const PRODUCTION_WSDL = 'https://service.postnl.com/CIF/LabellingWebService/2_1/?wsdl';
 
     /**
      * The URL of the sandbox WSDL.
      */
-    const SANDBOX_WSDL = 'https://testservice.postnl.com/CIF_SB/LabellingWebService/2_0/?wsdl';
+    const SANDBOX_WSDL = 'https://testservice.postnl.com/CIF_SB/LabellingWebService/2_1/?wsdl';
 
     /**
      * @var array $classes


### PR DESCRIPTION
The current interface version is 2.1, see https://developer.postnl.nl/apis/labelling-webservice/documentation