### PR TITLE
Add getter and setter for StreetHouseNrExt property

### DIFF
--- a/src/ComplexTypes/Address.php
+++ b/src/ComplexTypes/Address.php
@@ -85,8 +85,6 @@ class Address extends BaseType
 
     /**
      * @var string $StreetHouseNrExt
-     *     This is not used. Use separate street, house number and house number
-     *     extension parameters.
      */
     protected $StreetHouseNrExt = null;
 
@@ -230,6 +228,31 @@ class Address extends BaseType
     public function setCompanyName($CompanyName)
     {
         $this->CompanyName = $CompanyName;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStreetHouseNrExt()
+    {
+        return $this->StreetHouseNrExt;
+    }
+
+    /**
+     * Combination of Street, HouseNr and HouseNrExt.
+     *
+     * The PostNL webservice will calculate a split of street name, house number and extension for you, and will
+     * afterwards use the split values.
+     *
+     * Important: The conversion is only made for NL, BE and DE addresses.
+     *
+     * @param $streetHouseNrExt
+     * @return Address
+     */
+    public function setStreetHouseNrExt($streetHouseNrExt)
+    {
+        $this->StreetHouseNrExt = $streetHouseNrExt;
         return $this;
     }
 

--- a/src/ComplexTypes/Address.php
+++ b/src/ComplexTypes/Address.php
@@ -243,9 +243,11 @@ class Address extends BaseType
      * Combination of Street, HouseNr and HouseNrExt.
      *
      * The PostNL webservice will calculate a split of street name, house number and extension for you, and will
-     * afterwards use the split values.
+     * afterwards use the split values. This might result in incorrect behavior for which PostNL can’t be held liable.
      *
-     * Important: The conversion is only made for NL, BE and DE addresses.
+     * Important:
+     * - The conversion is only made for NL, BE and DE addresses.
+     * - Use separate fields (street, houseNr and extension) when possible.
      *
      * @param $streetHouseNrExt
      * @return Address

--- a/src/ComplexTypes/Address.php
+++ b/src/ComplexTypes/Address.php
@@ -249,7 +249,7 @@ class Address extends BaseType
      * - The conversion is only made for NL, BE and DE addresses.
      * - Use separate fields (street, houseNr and extension) when possible.
      *
-     * @param $streetHouseNrExt
+     * @param string $streetHouseNrExt
      * @return Address
      */
     public function setStreetHouseNrExt($streetHouseNrExt)


### PR DESCRIPTION
Adds a getter and setter for StreetHouseNrExt property.
PostNL uses this property to split an addresses into streetname, housenumber and extension automatically.

This PR fixes #51.