### PR TITLE
GetLocations: Allow setting delivery options

### DIFF
--- a/src/Postnl.php
+++ b/src/Postnl.php
@@ -398,16 +398,18 @@ class Postnl
      * @param string $allowSundaySorting
      * @param null|string $deliveryDate
      * @param string $countryCode
+     * @param array $deliveryOptions
      * @return ComplexTypes\GetNearestLocationsResponse
      */
     public function getNearestLocations(
         $postalCode,
         $allowSundaySorting = 'false',
         $deliveryDate = null,
-        $countryCode = 'NL'
+        $countryCode = 'NL',
+        $deliveryOptions = ['PG']
     ) {
         $message = new ComplexTypes\Message;
-        $location = new ComplexTypes\Location($postalCode, $allowSundaySorting, $deliveryDate);
+        $location = new ComplexTypes\Location($postalCode, $allowSundaySorting, $deliveryDate, $deliveryOptions);
 
         $request = new ComplexTypes\GetNearestLocationsRequest($message, $location, $countryCode);
         return $this->call('LocationClient', __FUNCTION__, $request);


### PR DESCRIPTION
This allows setting the `deliveryOptions` parameter through `getNearestLocations()`.
This is used to filter delivery locations based on types:
- `PG` 
  - Retail points and parcel lockers
- `PA` 
  - Parcel lockers only
- `PG_EX`
  - Retail points only